### PR TITLE
FIX Update Subsite namespace and ensure search boost extension exists before checking for its use

### DIFF
--- a/src/Extension/CwpControllerExtension.php
+++ b/src/Extension/CwpControllerExtension.php
@@ -13,7 +13,7 @@ use SilverStripe\Security\Member;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Security;
-use SilverStripe\Subsite\Model\Subsite;
+use SilverStripe\Subsites\Model\Subsite;
 
 class CwpControllerExtension extends Extension implements PermissionProvider
 {

--- a/src/Model/CwpSearchIndex.php
+++ b/src/Model/CwpSearchIndex.php
@@ -2,7 +2,7 @@
 
 namespace CWP\Core\Model;
 
-use CwpSearchBoostExtension;
+use CWP\CWP\Extensions\CwpSearchBoostExtension;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 use SilverStripe\FullTextSearch\Solr\SolrIndex;
@@ -24,10 +24,10 @@ abstract class CwpSearchIndex extends SolrIndex
      * @var array
      * @config
      */
-    private static $copy_fields = array(
+    private static $copy_fields = [
         '_text',
-        '_spellcheckText'
-    );
+        '_spellcheckText',
+    ];
 
     /**
      * Default dictionary to use. This will overwrite the 'spellcheck.dictionary' option for searches given,
@@ -44,7 +44,9 @@ abstract class CwpSearchIndex extends SolrIndex
     public function init()
     {
         // Add optional boost
-        if (SiteTree::has_extension(CwpSearchBoostExtension::class)) {
+        if (class_exists(CwpSearchBoostExtension::class)
+            && SiteTree::has_extension(CwpSearchBoostExtension::class)
+        ) {
             $this->setFieldBoosting(SiteTree::class . '_SearchBoost', SiteTree::config()->get('search_boost'));
         }
     }


### PR DESCRIPTION
Since the search boost extension lives in the cwp/cwp module, we should check if the class exists before using it in logic.

Issue: #1