### PR TITLE
[FEAT] Add 'X-XSS-Protection: 1; mode=block' header by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/cwp-core/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/cwp-core/?branch=master)
 [![codecov](https://codecov.io/gh/silverstripe/cwp-core/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/cwp-core)
 
+## About this module
+This module includes core configuration that is required for Common Web Platform sites to function correctly.
+
+### Configuration
+There are some settings that can be modified in this module, depending on requirements. These are listed below.
+
+#### XSS Protection
+By default, CWP sites instruct newer browsers to protect against cross-site scripting (XSS) attacks. This is done using an HTTP header (X-XSS-Protection). More information on this header can be found on the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection) site. To disable this feature, add the following to your YML configuration:
+```
+CWP\Core\Control\InitialisationMiddleware:
+  xss_protection_disabled: true
+```
+
+#### Egress Proxy settings
+CWP includes an egress proxy for all external requests made by SilverStripe sites running on CWP. This means that by default, all HTTP requests made using `curl` or PHP's stream functions are routed via a proxy. In some cases this may not be desired (e.g. if you wish to communicate with localhost). By default, there are two exceptions to this proxy: `services.cwp.govt.nz` and `localhost`. These cover all standard CWP use cases (e.g. searching via Solr).
+
+You can disable the egress proxy entirely by adding the following YML configuration:
+```
+CWP\Core\Control\InitialisationMiddleware:
+  egress_proxy_default_enabled: false
+```
+
+You can also add to the list of domains to disable the proxy by adding the following YML configuration:
+```
+CWP\Core\Control\InitialisationMiddleware:
+  egress_proxy_exclude_domains:
+    - example.com
+```
+
 ## Contributing
 
 ### Translations

--- a/tests/Control/InitialisationMiddlewareTest.php
+++ b/tests/Control/InitialisationMiddlewareTest.php
@@ -6,9 +6,9 @@ use CWP\Core\Control\InitialisationMiddleware;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Environment;
-use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Dev\FunctionalTest;
 
-class InitialisationMiddlewareTest extends SapphireTest
+class InitialisationMiddlewareTest extends FunctionalTest
 {
     /**
      * @var HTTPRequest
@@ -86,6 +86,20 @@ class InitialisationMiddlewareTest extends SapphireTest
             Environment::getEnv('NO_PROXY'),
             'Domain exclusions are combined with existing values and configuration settings'
         );
+    }
+
+    public function testSecurityHeadersAddedByDefault()
+    {
+        $response = $this->get('test');
+        $this->assertArrayHasKey('x-xss-protection', $response->getHeaders());
+        $this->assertSame('1; mode=block', $response->getHeader('x-xss-protection'));
+    }
+
+    public function testXSSProtectionHeaderNotAdded()
+    {
+        Config::modify()->set(InitialisationMiddleware::class, 'xss_protection_disabled', true);
+        $response = $this->get('test');
+        $this->assertArrayNotHasKey('x-xss-protection', $response->getHeaders());
     }
 
     /**


### PR DESCRIPTION
[FEAT] Add 'X-XSS-Protection: 1; mode=block' header by default to all CWP projects, with option to disable
[DOCS] Add documentation for the configurable values (xss_protection_disabled, egress_proxy_default_enabled and egress_proxy_exclude_domains)