### PR TITLE
Increase API positivity by using xss_protection_enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are some settings that can be modified in this module, depending on requir
 By default, CWP sites instruct newer browsers to protect against cross-site scripting (XSS) attacks. This is done using an HTTP header (X-XSS-Protection). More information on this header can be found on the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection) site. To disable this feature, add the following to your YML configuration:
 ```
 CWP\Core\Control\InitialisationMiddleware:
-  xss_protection_disabled: true
+  xss_protection_enabled: false
 ```
 
 #### Egress Proxy settings

--- a/src/Control/InitialisationMiddleware.php
+++ b/src/Control/InitialisationMiddleware.php
@@ -22,7 +22,7 @@ class InitialisationMiddleware implements HTTPMiddleware
      * @config
      * @var bool
      */
-    private static $xss_protection_disabled = false;
+    private static $xss_protection_enabled = true;
 
     /**
      * Enable egress proxy. This works on the principle of setting http(s)_proxy environment variables,
@@ -58,7 +58,7 @@ class InitialisationMiddleware implements HTTPMiddleware
         
         $this->configureProxyDomainExclusions();
 
-        if (!$this->config()->get('xss_protection_disabled') && $response) {
+        if ($this->config()->get('xss_protection_enabled') && $response) {
             $response->addHeader('X-XSS-Protection', '1; mode=block');
         }
 

--- a/tests/Control/InitialisationMiddlewareTest.php
+++ b/tests/Control/InitialisationMiddlewareTest.php
@@ -97,7 +97,7 @@ class InitialisationMiddlewareTest extends FunctionalTest
 
     public function testXSSProtectionHeaderNotAdded()
     {
-        Config::modify()->set(InitialisationMiddleware::class, 'xss_protection_disabled', true);
+        Config::modify()->set(InitialisationMiddleware::class, 'xss_protection_enabled', false);
         $response = $this->get('test');
         $this->assertArrayNotHasKey('x-xss-protection', $response->getHeaders());
     }


### PR DESCRIPTION
Switches out `xss_protection_disabled` for `xss_protection_enabled` for a more positive developer experience ;-)

Follow on from @chillu's comment on #25.