### PR TITLE
Use a framework-safe URL in XSS header tests when no CMS is installed

### DIFF
--- a/tests/Control/InitialisationMiddlewareTest.php
+++ b/tests/Control/InitialisationMiddlewareTest.php
@@ -90,7 +90,7 @@ class InitialisationMiddlewareTest extends FunctionalTest
 
     public function testSecurityHeadersAddedByDefault()
     {
-        $response = $this->get('test');
+        $response = $this->get('Security/login');
         $this->assertArrayHasKey('x-xss-protection', $response->getHeaders());
         $this->assertSame('1; mode=block', $response->getHeader('x-xss-protection'));
     }
@@ -98,7 +98,7 @@ class InitialisationMiddlewareTest extends FunctionalTest
     public function testXSSProtectionHeaderNotAdded()
     {
         Config::modify()->set(InitialisationMiddleware::class, 'xss_protection_enabled', false);
-        $response = $this->get('test');
+        $response = $this->get('Security/login');
         $this->assertArrayNotHasKey('x-xss-protection', $response->getHeaders());
     }
 


### PR DESCRIPTION
This module and cwp/cwp-recipe-core recipe don't include the CMS, and the errorpage module is included by recipe-cms so this breaks the tests when it tries to render a 404 on `/test`. `Security/*` is a framework path, so is safer to use for testing