### PR TITLE
FIX Remove attempt to import environment into config for docvert

### DIFF
--- a/_config/documentconverter.yml
+++ b/_config/documentconverter.yml
@@ -4,11 +4,6 @@ Only:
   moduleexists: silverstripe/documentconverter
   EnvVarSet: DOCVERT_USERNAME
 ---
-SilverStripe\DocumentConverter\ServiceConnector:
-  username: '`DOCVERT_USERNAME`'
-  password: '`DOCVERT_PASSWORD`'
-  url: '`DOCVERT_URL`'
-
 Page:
   extensions:
     - SilverStripe\DocumentConverter\PageExtension


### PR DESCRIPTION
Currently this default is non-functional, and e.g. the URL gets set to
```
`DOCVERT_URL`
```
which clearly is not a URL, nor even a valid domain.
As this docvert prioritises config over environment, this makes a mess of any attempts to import data by making the docvert server unreachable.