### PR TITLE
FIX LoginAttemptNotifications extension is now disabled again, as it is in CWP 1.x

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -1,9 +1,12 @@
 ---
 Name: cwpcoreextensions
 ---
-SilverStripe\Admin\LeftAndMain:
-  extensions:
-    - CWP\Core\Extension\LoginAttemptNotifications
+# @todo Disable the feature. LoginAttempt seems to be broken on bridging solution - logs every
+# request instead of logins!
+# Follow up issue: https://github.com/silverstripe/cwp-core/issues/41
+# SilverStripe\Admin\LeftAndMain:
+#   extensions:
+#     - CWP\Core\Extension\LoginAttemptNotifications
 
 SilverStripe\ORM\FieldType\DBField:
   extensions:


### PR DESCRIPTION
For context, see #41 