### PR TITLE
FIX SilverStripe debug logs and higher are now routed correctly to syslog (Graylog)

### DIFF
--- a/_config/logging.yml
+++ b/_config/logging.yml
@@ -1,0 +1,13 @@
+---
+Name: cwpcorelogging
+After: '#logging'
+---
+SilverStripe\Core\Injector\Injector:
+  Psr\Log\LoggerInterface:
+    calls:
+      pushSilverStripeSyslogHandler: [ pushHandler, [ '%$Monolog\Handler\HandlerInterface.silverstripe' ] ]
+  # Internal error handler, piped to syslog which is routed to Graylog
+  Monolog\Handler\HandlerInterface.silverstripe:
+    class: Monolog\Handler\SyslogHandler
+    constructor:
+      - 'SilverStripe_log'


### PR DESCRIPTION
As @madmatt pointed out, debugged and solved in #43, this change was somehow missed while upgrading from CWP 1.x to 2.x.

Resolves #43