### PR TITLE
FIX Updating default session timeout to CWP default for consistency

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -10,7 +10,7 @@ SilverStripe\Admin\LeftAndMain:
   session_keepalive_ping: false
 
 SilverStripe\Control\Session:
-  timeout: 3600
+  timeout: 1440
 
 SilverStripe\Forms\PasswordField:
   autocomplete: false


### PR DESCRIPTION
Part of #40

This adjusts the default session timeout (cookie) to the default `session.gc_maxlifetime` timeout in PHP configuration on CWP.