### PR TITLE
FIX Re-instate CWP recipe version in help menu

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -20,3 +20,7 @@ SilverStripe\Security\Group:
 HtmlEditorField_Toolbar:
   extensions:
    - CWP\Core\Extension\CustomHtmlEditorFieldToolbar
+
+SilverStripe\Admin\LeftAndMain:
+  extensions:
+    - CWP\Core\Extension\CWPVersionExtension

--- a/_config/version.yml
+++ b/_config/version.yml
@@ -6,6 +6,4 @@ After:
 ---
 SilverStripe\Core\Manifest\VersionProvider:
   modules:
-    silverstripe/framework: ''
-    silverstripe/cms: ''
     cwp/cwp-core: 'CWP'

--- a/_config/version.yml
+++ b/_config/version.yml
@@ -1,0 +1,11 @@
+---
+Name: cwpversion
+After:
+  - '#cmsversion'
+  - '#coreconfig'
+---
+SilverStripe\Core\Manifest\VersionProvider:
+  modules:
+    silverstripe/framework: ''
+    silverstripe/cms: ''
+    cwp/cwp-core: 'CWP'

--- a/css/custom.css
+++ b/css/custom.css
@@ -39,4 +39,9 @@
 
 .cms-help__toggle-cwp-title {
     font-size: 9px;
+    display: flex;
+}
+
+.cms-help__badge {
+    align-self: flex-start;
 }

--- a/css/custom.css
+++ b/css/custom.css
@@ -27,3 +27,16 @@
 .alignExtraLabel label{
 	line-height:2em;
 }
+
+/* See vendor/silverstripe/admin/client/src/components/Menu/Menu.scss */
+.cms-help__logo {
+    min-width: 26px;
+}
+
+.cms-help__toggle-title {
+    line-height: 12px;
+}
+
+.cms-help__toggle-cwp-title {
+    font-size: 9px;
+}

--- a/src/Extension/CWPVersionExtension.php
+++ b/src/Extension/CWPVersionExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace CWP\Core\Extension;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Core\Manifest\VersionProvider;
+
+class CWPVersionExtension extends Extension
+{
+    /**
+     * Gets the version of cwp/cwp-core and returns the major.minor version from it
+     *
+     * @return string
+     */
+    public function getCWPVersionNumber()
+    {
+        /** @var VersionProvider $versionProvider */
+        $versionProvider = $this->owner->getVersionProvider();
+
+        $modules = $versionProvider->getModuleVersionFromComposer(['cwp/cwp-core']);
+        if (empty($modules)) {
+            return '';
+        }
+
+        // Example: "2.2.x-dev"
+        $cwpCore = $modules['cwp/cwp-core'];
+        return (string) substr($cwpCore, 0, strpos($cwpCore, '.', 2));
+    }
+}

--- a/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuToggle.ss
+++ b/templates/SilverStripe/Admin/Includes/LeftAndMain_MenuToggle.ss
@@ -1,0 +1,37 @@
+<%-- See silverstripe/admin:templates/SilverStripe/Admin/Includes/LeftAndMain_MenuToggle.ss --%>
+<div class="cms-help__toggle">
+    <button class="cms-help__menu" type="button" title="<%t SilverStripe\Admin\LeftAndMain.HelpMenu "Help menu" %>" aria-label="<%t SilverStripe\Admin\LeftAndMain.HelpMenu "Help menu" %>" aria-expanded="false">
+        <span class="cms-help__logo font-icon-silverstripe"></span>
+        <span class="cms-help__toggle-title">
+            $ApplicationName
+            <%-- Modification from core template --%>
+            <span class="cms-help__toggle-cwp-title text-sm">
+                CWP $CWPVersionNumber
+            </span>
+            <%-- End modification from core template --%>
+        </span>
+        <span class="cms-help__badge badge badge-info">
+            <% if $CMSVersionNumber %>
+                <span class="cms-sitename__version" title="$ApplicationName (<%t SilverStripe\Admin\LeftAndMain.Version "Version" %> - $CMSVersion)">$CMSVersionNumber.LimitCharacters(3, '')</span>
+            <% end_if %>
+        </span>
+        <span class="cms-help__caret font-icon-caret-down-two"></span>
+    </button>
+    <% if $HelpLinks %>
+        <div class="cms-help__links">
+            <% loop $HelpLinks %>
+                <% if $URL %>
+                    <a class="cms-help__link" href="$URL" target="_blank" rel="noopener noreferrer">$Title</a>
+                <% end_if %>
+            <% end_loop %>
+        </div>
+    <% end_if %>
+</div>
+
+<div class="sticky-toggle">
+    <button class="sticky-toggle__button" type="button" title="<%t SilverStripe\Admin\LeftAndMain.MenuToggleStickyNav "Sticky nav" %>"><%t SilverStripe\Admin\LeftAndMain.MenuToggleStickyNav "Sticky nav" %></button>
+    <span class="sticky-toggle__status sticky-status-indicator"><%t SilverStripe\Admin\LeftAndMain.MenuToggleAuto "Auto" %></span>
+</div>
+
+<a class="toggle-expand" href="#" data-toggle="tooltip" title="<%t SilverStripe\Admin\LeftAndMain.ExpandPanel "Expand panel" %>" aria-label="<%t SilverStripe\Admin\LeftAndMain.ExpandPanel "Expand panel" %>"><span>&raquo;</span></a>
+<a class="toggle-collapse" href="#" data-toggle="tooltip" title="<%t SilverStripe\Admin\LeftAndMain.CollapsePanel "Collapse panel" %>" aria-label="<%t SilverStripe\Admin\LeftAndMain.CollapsePanel "Collapse panel" %>"><span>&laquo;</span></a>

--- a/tests/Extension/CWPVersionExtensionTest.php
+++ b/tests/Extension/CWPVersionExtensionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace CWP\Core\Tests\Extension;
+
+use CWP\Core\Extension\CWPVersionExtension;
+use PHPUnit_Framework_MockObject_MockObject;
+use SilverStripe\Admin\LeftAndMain;
+use SilverStripe\Core\Manifest\VersionProvider;
+use SilverStripe\Dev\SapphireTest;
+
+class CWPVersionExtensionTest extends SapphireTest
+{
+    /**
+     * @var VersionProvider|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $versionProvider;
+
+    /**
+     * @var LeftAndMain|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $leftAndMain;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->versionProvider = $this->createMock(VersionProvider::class);
+        $this->leftAndMain = $this->createMock(LeftAndMain::class);
+
+        $this->leftAndMain
+            ->expects($this->atLeastOnce())
+            ->method('getVersionProvider')
+            ->willReturn($this->versionProvider);
+    }
+
+    /**
+     * @param array $modules
+     * @param string $expected
+     * @dataProvider getVersionProvider
+     */
+    public function testGetVersion($modules, $expected)
+    {
+        $this->versionProvider->expects($this->once())
+            ->method('getModuleVersionFromComposer')
+            ->willReturn($modules);
+
+        $extension = new CWPVersionExtension();
+        $extension->setOwner($this->leftAndMain);
+
+        $result = $extension->getCWPVersionNumber();
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function getVersionProvider()
+    {
+        return [
+            'dev version' => [['cwp/cwp-core' => '2.3.x-dev'], '2.3'],
+            'stable version' => [['cwp/cwp-core' => '2.2.0'], '2.2'],
+            'not found' => [[], ''],
+        ];
+    }
+}


### PR DESCRIPTION
This reinstates the missing version provider configuration. I don't know where this went, but it was introduced in CWP 1.9 and should have been in CWP 2.x.

Fixes #57 

This is what it looks like now: 
![image](https://user-images.githubusercontent.com/5170590/48195115-6a4ea900-e357-11e8-8584-6b94a407e221.png)

Previously the version number wasn't shown until you hovered over the logo, which would then say `SilverStripe (Version - CWP: 2.2.x-dev)`. With the redesigned help menu, it might be misleading to have `2.2` next to `SilverStripe`. I [previously asked](https://github.com/silverstripe/silverstripe-admin/pull/615#issuecomment-427324114) whether we should change this to "CWP" for CWP, but we decided not to.

@clarkepaul @sachajudd might need your input here before this gets merged