### PR TITLE
FIX Run password config after core configuration

### DIFF
--- a/_config/security.yml
+++ b/_config/security.yml
@@ -1,5 +1,6 @@
 ---
 Name: cwppasswordstrength
+After: '#corepasswords'
 ---
 # In the case someone uses `new PasswordValidator` instead of Injector, provide some safe defaults through config.
 # Test names will not be set however, as it is not configurable.


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-framework/pull/8587 and https://github.com/silverstripe/recipe-core/pull/34

Issue: https://github.com/silverstripe/cwp-core/issues/52