### PR TITLE
[FIX] Configure egress proxy in Middleware

### DIFF
--- a/src/Control/InitialisationMiddleware.php
+++ b/src/Control/InitialisationMiddleware.php
@@ -50,13 +50,13 @@ class InitialisationMiddleware implements HTTPMiddleware
 
     public function process(HTTPRequest $request, callable $delegate)
     {
-        $response = $delegate($request);
-
         if ($this->config()->get('egress_proxy_default_enabled')) {
             $this->configureEgressProxy();
         }
-        
+
         $this->configureProxyDomainExclusions();
+
+        $response = $delegate($request);
 
         if ($this->config()->get('xss_protection_enabled') && $response) {
             $response->addHeader('X-XSS-Protection', '1; mode=block');


### PR DESCRIPTION
In InitialisationMiddleWare configure the egress proxy and domain exclusions before delegating the request.
This is change fixes an issue where the variables for `http_proxy`, `https_proxy` and `NO_PROXY` are configured after the request is processed by the controller and other Middlewares.