### PR TITLE
Use putenv() in InitialisationMiddleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
   # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-core 1.1.x-dev
+  - composer require --no-update silverstripe/recipe-core:1.1.x-dev silverstripe/versioned:1.1.x-dev
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/src/Control/InitialisationMiddleware.php
+++ b/src/Control/InitialisationMiddleware.php
@@ -50,13 +50,13 @@ class InitialisationMiddleware implements HTTPMiddleware
 
     public function process(HTTPRequest $request, callable $delegate)
     {
-        $response = $delegate($request);
-
         if ($this->config()->get('egress_proxy_default_enabled')) {
             $this->configureEgressProxy();
         }
-        
+
         $this->configureProxyDomainExclusions();
+
+        $response = $delegate($request);
 
         if ($this->config()->get('xss_protection_enabled') && $response) {
             $response->addHeader('X-XSS-Protection', '1; mode=block');

--- a/src/Control/InitialisationMiddleware.php
+++ b/src/Control/InitialisationMiddleware.php
@@ -80,8 +80,15 @@ class InitialisationMiddleware implements HTTPMiddleware
         $proxy = Environment::getEnv('SS_OUTBOUND_PROXY');
         $proxyPort = Environment::getEnv('SS_OUTBOUND_PROXY_PORT');
 
-        Environment::setEnv('http_proxy', $proxy . ':' . $proxyPort);
-        Environment::setEnv('https_proxy', $proxy . ':' . $proxyPort);
+        /*
+         * This sets the environment variables so they are available in
+         * external calls executed by exec() such as curl.
+         * Environment::setEnv() would only availabe in context of SilverStripe.
+         * Environment::getEnv() will fallback to getenv() and will therefore
+         * fetch the variables
+         */
+        putenv('http_proxy=' .  $proxy . ':' . $proxyPort);
+        putenv('https_proxy=' . $proxy . ':' . $proxyPort);
     }
 
     /**
@@ -103,6 +110,10 @@ class InitialisationMiddleware implements HTTPMiddleware
             $noProxy = array_merge(explode(',', Environment::getEnv('NO_PROXY')), $noProxy);
         }
 
-        Environment::setEnv('NO_PROXY', implode(',', array_unique($noProxy)));
+        /*
+         * Set the environment varial for NO_PROXY the same way the
+         * proxy variables are set above
+         */
+        putenv('NO_PROXY=' . implode(',', array_unique($noProxy)));
     }
 }

--- a/tests/Control/InitialisationMiddlewareTest.php
+++ b/tests/Control/InitialisationMiddlewareTest.php
@@ -3,14 +3,10 @@
 namespace CWP\Core\Tests\Control;
 
 use CWP\Core\Control\InitialisationMiddleware;
-use function getenv;
-use function print_r;
-use function putenv;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Environment;
 use SilverStripe\Dev\FunctionalTest;
-use function var_dump;
 
 class InitialisationMiddlewareTest extends FunctionalTest
 {

--- a/tests/Control/InitialisationMiddlewareTest.php
+++ b/tests/Control/InitialisationMiddlewareTest.php
@@ -3,10 +3,14 @@
 namespace CWP\Core\Tests\Control;
 
 use CWP\Core\Control\InitialisationMiddleware;
+use function getenv;
+use function print_r;
+use function putenv;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Environment;
 use SilverStripe\Dev\FunctionalTest;
+use function var_dump;
 
 class InitialisationMiddlewareTest extends FunctionalTest
 {
@@ -31,7 +35,7 @@ class InitialisationMiddlewareTest extends FunctionalTest
 
         Environment::setEnv('SS_OUTBOUND_PROXY', '');
         Environment::setEnv('SS_OUTBOUND_PROXY_PORT', '');
-        Environment::setEnv('NO_PROXY', '');
+        putenv('NO_PROXY=');
     }
 
     public function testDoNotConfigureProxyIfNoEnvironmentVarsAreSet()
@@ -79,8 +83,7 @@ class InitialisationMiddlewareTest extends FunctionalTest
             'example.com'
         );
 
-        Environment::setEnv('NO_PROXY', 'foo.com,bar.com');
-
+        putenv('NO_PROXY=foo.com,bar.com');
         $this->runMiddleware();
 
         $this->assertSame(


### PR DESCRIPTION
This commit it based on changing the order of execution in InitialisationMiddleware.
It proposes to change the setting of the environment variables for `http_proxy`, `https_proxy` and `NO_PROXY` from `Environment::setEnv()` back to `putenv()` as it was in CWP1.

As described in the documentation of InitialisationMiddleware its main purpose is to configure the proxy so it is automatically picked up when calling `curl` in an apache context.
I'm aware of the multithreaded issue described in https://github.com/laravel/framework/issues/7354, but considering that these variables should be present anyway, I don't consider that to be an issue in context of CWP.  Maybe @tractorcow has some insights into that?

Otherwise the variables are redundant as `SS_OUTBOUND_PROXY`, `SS_OUTBOUND_PROXY_PORT` and `NO_PROXY` already exist.
