### PR TITLE
FIX CwpBasicAuthMiddleware::setWhitelistedIps() now accepts comma delimited IP lists within an array of values

### DIFF
--- a/src/Control/CwpBasicAuthMiddleware.php
+++ b/src/Control/CwpBasicAuthMiddleware.php
@@ -28,15 +28,27 @@ class CwpBasicAuthMiddleware extends BasicAuthMiddleware implements PermissionPr
     }
 
     /**
-     * @param string|string[] $whitelistedIps An array of IP addresses, or a comma delimited string
+     * @param string|string[] $whitelistedIps An array of IP addresses, a comma delimited string, or an array of IPs
+     *                                        or comma delimited IP list strings
      * @return $this
      */
     public function setWhitelistedIps($whitelistedIps)
     {
-        if (is_string($whitelistedIps)) {
-            $whitelistedIps = explode(',', $whitelistedIps);
+        // Allow string or array input
+        $ipLists = is_array($whitelistedIps) ? $whitelistedIps : [$whitelistedIps];
+
+        $whitelistedIps = [];
+        // Break each string in the array by commas to support nested IP lists
+        foreach ($ipLists as $ipList) {
+            if (!$ipList) {
+                continue;
+            }
+            $ips = array_map('trim', explode(',', $ipList));
+            $whitelistedIps = array_merge($whitelistedIps, $ips);
         }
-        $this->whitelistedIps = $whitelistedIps;
+
+        // Return unique values with keys reset
+        $this->whitelistedIps = array_values(array_unique($whitelistedIps));
         return $this;
     }
 

--- a/tests/Control/CwpBasicAuthMiddlewareTest.php
+++ b/tests/Control/CwpBasicAuthMiddlewareTest.php
@@ -40,16 +40,38 @@ class CwpBasicAuthMiddlewareTest extends SapphireTest
         parent::tearDown();
     }
 
-    public function testSetWhitelistedIps()
+    public function testSetWhitelistedIpsAcceptsStrings()
     {
         $this->middleware->setWhitelistedIps('127.0.0.1,127.0.0.2');
         $this->assertSame([
             '127.0.0.1',
             '127.0.0.2',
         ], $this->middleware->getWhitelistedIps(), 'Accepts comma delimited strings');
+    }
 
+    public function testSetWhitelistedIpsAcceptsArraysOfStrings()
+    {
         $this->middleware->setWhitelistedIps(['127.0.0.1']);
         $this->assertSame(['127.0.0.1'], $this->middleware->getWhitelistedIps(), 'Accepts array values');
+    }
+
+    public function testSetWhitelistedIpsSupportedNestedStringListsInsideArrays()
+    {
+        $this->middleware->setWhitelistedIps([
+            '127.0.0.1,127.0.0.2', // Example of `CWP_IP_BYPASS_BASICAUTH` env var value
+            ' 137.0.0.1 , 127.0.0.2', // Example of `CWP_IP_BYPASS_BASICAUTH` env var value with added spaces
+            '127.0.0.3',
+            '127.0.0.3', // check results are unique
+            '127.0.0.4',
+        ]);
+
+        $this->assertSame([
+            '127.0.0.1',
+            '127.0.0.2',
+            '137.0.0.1',
+            '127.0.0.3',
+            '127.0.0.4',
+        ], $this->middleware->getWhitelistedIps(), 'Accepts IP list strings inside arrays');
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/silverstripe/cwp-core/issues/64