### PR TITLE
NEW Add PBKDF2 PasswordEncryptor with SHA-512 as the default algorithm for NZISM compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,12 @@ language: php
 
 matrix:
   include:
-    - php: 5.6
-      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
-    - php: 7.0
-      env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.2
       env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.3
-      env: DB=MYSQL PHPUNIT_TEST=1
+      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
 
 before_script:
   # Init PHP
@@ -21,7 +17,7 @@ before_script:
 
   # Install composer dependencies
   - composer validate
-  - composer require --no-update silverstripe/recipe-core:4.4.x-dev silverstripe/versioned:1.4.x-dev
+  - composer require --no-update silverstripe/recipe-core:4.5.x-dev silverstripe/versioned:1.5.x-dev
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/_config/encryptors.yml
+++ b/_config/encryptors.yml
@@ -1,0 +1,11 @@
+---
+name: cwpencryptors
+---
+SilverStripe\Security\PasswordEncryptor:
+  encryptors:
+    pbkdf2_sha512:
+      CWP\Core\PasswordEncryptor\PBKDF2: sha512
+
+# Enable SHA-512 via PBKDF2 by default, for NZISM compliance
+SilverStripe\Security\Security:
+  password_encryption_algorithm: pbkdf2_sha512

--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
         "cwp"
     ],
     "require": {
-        "silverstripe/framework": "^4.4@dev",
-        "silverstripe/admin": "^1.4@dev",
+        "silverstripe/framework": "^4.5@dev",
+        "silverstripe/admin": "^1.5@dev",
         "silverstripe/hybridsessions": "^2",
         "silverstripe/environmentcheck": "^2",
         "silverstripe/auditor": "^2"

--- a/src/PasswordEncryptor/PBKDF2.php
+++ b/src/PasswordEncryptor/PBKDF2.php
@@ -12,7 +12,9 @@ use SilverStripe\Security\PasswordEncryptor_PHPHash;
 class PBKDF2 extends PasswordEncryptor_PHPHash
 {
     /**
-     * The number of internal iterations for hash_pbkdf2() to perform for the derivation.
+     * The number of internal iterations for hash_pbkdf2() to perform for the derivation. Please note that if you
+     * change this from the default value you will break existing hashes stored in the database, so these would
+     * need to be regenerated.
      *
      * @var int
      */

--- a/src/PasswordEncryptor/PBKDF2.php
+++ b/src/PasswordEncryptor/PBKDF2.php
@@ -44,6 +44,6 @@ class PBKDF2 extends PasswordEncryptor_PHPHash
 
     public function encrypt($password, $salt = null, $member = null)
     {
-        return hash_pbkdf2($this->getAlgorithm(), $password, $salt, $this->getIterations());
+        return hash_pbkdf2($this->getAlgorithm(), (string) $password, (string) $salt, $this->getIterations());
     }
 }

--- a/src/PasswordEncryptor/PBKDF2.php
+++ b/src/PasswordEncryptor/PBKDF2.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace CWP\Core\PasswordEncryptor;
+
+use Exception;
+use SilverStripe\Security\PasswordEncryptor_PHPHash;
+
+/**
+ * Provides Password-Based Key Derivation Function hashing for passwords, using the provided algorithm (default
+ * is SHA512), which is NZISM compliant under version 3.2 section 17.2.
+ */
+class PBKDF2 extends PasswordEncryptor_PHPHash
+{
+    /**
+     * The number of internal iterations for hash_pbkdf2() to perform for the derivation.
+     *
+     * @var int
+     */
+    protected $iterations = 10000;
+
+    /**
+     * @param string $algorithm
+     * @param int|null $iterations
+     * @throws Exception If the provided algorithm is not available in the current environment
+     */
+    public function __construct(string $algorithm, int $iterations = null)
+    {
+        parent::__construct($algorithm);
+
+        if ($iterations !== null) {
+            $this->iterations = $iterations;
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getIterations(): int
+    {
+        return $this->iterations;
+    }
+
+    public function encrypt($password, $salt = null, $member = null)
+    {
+        return hash_pbkdf2($this->getAlgorithm(), $password, $salt, $this->getIterations());
+    }
+}

--- a/tests/PasswordEncryptor/PBKDF2Test.php
+++ b/tests/PasswordEncryptor/PBKDF2Test.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace CWP\Core\Tests\PasswordEncryptor;
+
+use CWP\Core\PasswordEncryptor\PBKDF2;
+use League\Flysystem\Exception;
+use SilverStripe\Dev\SapphireTest;
+
+class PBKDF2Test extends SapphireTest
+{
+    public function testGetIterations()
+    {
+        $encryptor = new PBKDF2('sha512', 12345);
+        $this->assertSame(12345, $encryptor->getIterations());
+    }
+
+    public function testEncrypt()
+    {
+        $encryptor = new PBKDF2('sha512');
+        $salt = 'predictablesaltforunittesting';
+        $result = $encryptor->encrypt('opensesame', $salt);
+        $this->assertSame(
+            '6bafcacb90',
+            substr($result, 0, 10),
+            'Hashed password with predictable salt did not match fixtured expectation'
+        );
+    }
+
+    /**
+     * @expectedException Exception
+     * @expectedExceptionMessage Hash algorithm "foobar" not found
+     */
+    public function testThrowsExceptionWhenInvalidAlgorithmIsProvided()
+    {
+        new PBKDF2('foobar');
+    }
+}

--- a/tests/PasswordEncryptor/PBKDF2Test.php
+++ b/tests/PasswordEncryptor/PBKDF2Test.php
@@ -16,7 +16,7 @@ class PBKDF2Test extends SapphireTest
 
     public function testEncrypt()
     {
-        $encryptor = new PBKDF2('sha512');
+        $encryptor = new PBKDF2('sha512', 10000);
         $salt = 'predictablesaltforunittesting';
         $result = $encryptor->encrypt('opensesame', $salt);
         $this->assertSame(


### PR DESCRIPTION
This also updates the core constraints to SilverStripe 4.5, which requires PHP 7.1, and updates the Travis build matrix to match.

Resolves #51