### PR TITLE
NEW Opt-in HTTP Strict Transport Headers

### DIFF
--- a/tests/Control/InitialisationMiddlewareTest.php
+++ b/tests/Control/InitialisationMiddlewareTest.php
@@ -103,6 +103,20 @@ class InitialisationMiddlewareTest extends FunctionalTest
         $this->assertArrayNotHasKey('x-xss-protection', $response->getHeaders());
     }
 
+    public function testHstsNotAddedByDefault()
+    {
+        Config::modify()->remove(InitialisationMiddleware::class, 'strict_transport_security');
+        $response = $this->get('Security/login');
+        $this->assertArrayNotHasKey('strict-transport-security', $response->getHeaders());
+    }
+
+    public function testHstsAddedWhenConfigured()
+    {
+        Config::modify()->update(InitialisationMiddleware::class, 'strict_transport_security', 'max-age=1');
+        $response = $this->get('Security/login');
+        $this->assertArrayHasKey('strict-transport-security', $response->getHeaders());
+    }
+
     /**
      * Runs the middleware with a stubbed delegate
      */


### PR DESCRIPTION
See https://github.com/silverstripe/cwp-installer/issues/24.
Can't configure this by default since it would violate semver.

Added to the cwp-core because that's a context where we can safely assume
valid SSL operation in test and production environments.

Added to PHP rather than htaccess since we can't assume SSL is available
on dev environments, and it'll be a really annoying blocker for devs to track down.

Added to InitialisationMiddleware since it's already modifying HTTP headers (`X-XSS-Protection`).

This isn't ideal, since it conflicts with guidance on our wider open source docs:
https://docs.silverstripe.org/en/4/developer_guides/security/secure_coding/.
But I'd say this guidance is outdated, adding headers in a specific
controller doesn't provide enough coverage. And in the case of introducing
this to CWP, we would rely on developers adding it to their own codebase.

Related to https://github.com/silverstripe/cwp/pull/223