### PR TITLE
Fix cwptextextraction config (issue #74) 

### DIFF
--- a/_config/textextraction.yml
+++ b/_config/textextraction.yml
@@ -1,11 +1,12 @@
 ---
 Name: cwptextextraction
-After: '#textextraction'
+After: '#textextractionconfig'
 Only:
   moduleexists: silverstripe/textextraction
 ---
 SilverStripe\Core\Injector\Injector:
-  FileTextCache: FileTextCache_SSCache
+  SilverStripe\TextExtraction\Cache\FileTextCache:
+    class: SilverStripe\TextExtraction\Cache\FileTextCache\Cache
 
 SilverStripe\Assets\File:
   extensions:


### PR DESCRIPTION
This fixes issue #74 to re-enable cwp specific config for silverstripe/textextraction and use class `SilverStripe\TextExtraction\Cache\FileTextCache\Cache` instead of the current configuration of https://github.com/silverstripe/cwp-core/blob/1108756119fd36790ba1ecd30076c555eb3075f2/_config/textextraction.yml#L8 

This means FileTextCaching is used instead of caching extracted text in the database as it is the fallback right now and is different to the SilverStripe 3 compatible versions.