### PR TITLE
Increase iterations used by PBKDF2 per security recommendation

### DIFF
--- a/src/PasswordEncryptor/PBKDF2.php
+++ b/src/PasswordEncryptor/PBKDF2.php
@@ -18,7 +18,7 @@ class PBKDF2 extends PasswordEncryptor_PHPHash
      *
      * @var int
      */
-    protected $iterations = 10000;
+    protected $iterations = 30000;
 
     /**
      * @param string $algorithm


### PR DESCRIPTION
This will result in a 3x increase in compute time for generation / verification of passwords. Since authenticating a user is a fairly infrequent activity (compared to the volume of other requests), this should be an acceptable trade-off.