### PR TITLE
BUG max-age syntax in comments is incorrect

### DIFF
--- a/src/Control/InitialisationMiddleware.php
+++ b/src/Control/InitialisationMiddleware.php
@@ -61,7 +61,7 @@ class InitialisationMiddleware implements HTTPMiddleware
      *   environment: dev
      * ---
      * CWP\Core\Control\InitialisationMiddleware:
-     *   strict_transport_security: 'max-age: 300'
+     *   strict_transport_security: 'max-age=300'
      * SilverStripe\Core\Injector\Injector:
      *   SilverStripe\Control\Middleware\CanonicalURLMiddleware:
      *     properties:


### PR DESCRIPTION
The syntax for the HSTS related 'max-age' is incorrect, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security

Parent issue: https://github.com/silverstripe/cwp-installer/issues/29

Related: https://github.com/silverstripe/cwp-installer/pull/31