### PR TITLE
Update textextraction config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 matrix:
   include:
     - php: 5.6

--- a/_config/textextraction.yml
+++ b/_config/textextraction.yml
@@ -1,11 +1,12 @@
 ---
 Name: cwptextextraction
-After: '#textextraction'
+After: '#textextractionconfig'
 Only:
   moduleexists: silverstripe/textextraction
 ---
 SilverStripe\Core\Injector\Injector:
-  FileTextCache: FileTextCache_SSCache
+  SilverStripe\TextExtraction\Cache\FileTextCache:
+    class: SilverStripe\TextExtraction\Cache\FileTextCache\Cache
 
 SilverStripe\Assets\File:
   extensions:


### PR DESCRIPTION
This is a cherry-pick of previous commit to 2 that went into 2.3 though not 2.2
https://github.com/silverstripe/cwp-core/commit/192dcaebdc07351fa5ce198ab9449e861171367d

It's to fix this test in cwp-recipe-kitchen-sink
https://travis-ci.org/silverstripe/cwp-recipe-kitchen-sink/jobs/625881938

Basically what was happening is that an extra version of a File was being written though not published, so a logged out $file->canView() check was failing because the draft version was 3 while the live version was 2


