### PR TITLE
FIX Add resetaccount route to basic auth exceptions

### DIFF
--- a/_config/security.yml
+++ b/_config/security.yml
@@ -69,6 +69,7 @@ SilverStripe\Core\Injector\Injector:
       URLPatterns:
         '#^Security/lostpassword#i': false
         '#^Security/changepassword#i': false
+        '#^Security/resetaccount#i': false
         '#.*#': ACCESS_UAT_SERVER
   SilverStripe\Control\Middleware\CanonicalURLMiddleware:
     properties:


### PR DESCRIPTION
This was preventing MFA Account Resets on UAT environments.