### PR TITLE
API Allowing autocomplete on password fields

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,9 +12,6 @@ SilverStripe\Admin\LeftAndMain:
 SilverStripe\Control\Session:
   timeout: 1440
 
-SilverStripe\Forms\PasswordField:
-  autocomplete: false
-
 SilverStripe\Security\Member:
   lock_out_after_incorrect_logins: 5
   lock_out_delay_mins: 15


### PR DESCRIPTION
This was disabled way back in CWP 1.x, with an unclear rationale.
In 2021, we want to encourage users to use password managers,
which often rely on the password field allowing autocomplete.

From MDN (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password#allowing_autocomplete):

"off": Don't allow the browser or password manager to automatically fill out the password field. Note that some software ignores this value, since it's typically harmful to users' ability to maintain safe password practices.