### PR TITLE
FIX Update oembed config

### DIFF
--- a/_config/oembed.yml
+++ b/_config/oembed.yml
@@ -8,16 +8,6 @@ Only:
 ---
 SilverStripe\Core\Injector\Injector:
   # Configure the CWP proxy if defined
-  Embed\Http\DispatcherInterface:
-    class: Embed\Http\CurlDispatcher
+  Psr\Http\Client\ClientInterface.oembed:
     constructor:
-      config:
-        # CURLOPT_PROXY = 10004
-        10004: '`SS_OUTBOUND_PROXY`'
-        # CURLOPT_PROXYPORT = 59
-        59: '`SS_OUTBOUND_PROXY_PORT`'
-
-  # Provide dispatcher to Embeddable implementations
-  SilverStripe\View\Embed\Embeddable:
-    properties:
-      Dispatcher: '%$Embed\Http\DispatcherInterface'
+      - proxy: '`SS_OUTBOUND_PROXY`:`SS_OUTBOUND_PROXY_PORT`'

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.11",
         "silverstripe/admin": "^1.10",
         "silverstripe/hybridsessions": "^2",
         "silverstripe/environmentcheck": "^2",

--- a/tests/OEmbedTest.php
+++ b/tests/OEmbedTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CWP\Core\Tests;
+
+use Embed\Http\Crawler;
+use GuzzleHttp\Client;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+
+class OEmbedTest extends SapphireTest
+{
+    /**
+     * Ensure that the Psr\Http\Client\ClientInterface.oembed created is a
+     * GuzzleHttp\Client which can have the CWP outband proxy configuration applied to it
+     *
+     * This is to ensure the config in cwp-core/_config/oembed.yml aligns with the
+     * configured ClientInterface in the required version of framework
+     */
+    public function testGuzzleProxyConfig()
+    {
+        $reflClass = new \ReflectionClass(Crawler::class);
+        $reflProperty = $reflClass->getProperty('client');
+        $reflProperty->setAccessible(true);
+        $crawler = Injector::inst()->get(Crawler::class);
+        $client = $reflProperty->getValue($crawler);
+        $this->assertSame(Client::class, get_class($client));
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10305

Requires https://github.com/silverstripe/silverstripe-framework/pull/10312 to allow multiple backtick values to be set at once

Requires https://github.com/silverstripe/silverstripe-framework/pull/10311 so that guzzle is being used

Release ~~2.10.1~~ 2.11.0-beta1 when merged