### PR TITLE
FIX Require PHP 7.4 compatible version of silverstripe/auditor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "silverstripe/admin": "^1.10",
         "silverstripe/hybridsessions": "^2",
         "silverstripe/environmentcheck": "^2",
-        "silverstripe/auditor": "^2"
+        "silverstripe/auditor": "^2.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Fix https://github.com/silverstripe/cwp-core/runs/7487513822?check_suite_focus=true#step:12:68
`1) CWP\Core\Tests\Control\InitialisationMiddlewareTest::testDoNotConfigureProxyIfNoEnvironmentVarsAreSet
implode(): Passing glue string after array is deprecated. Swap the parameters`