### PR TITLE
FIX Remove misspelt name of QueuedJobService

### DIFF
--- a/_config/queuedjobs.yml
+++ b/_config/queuedjobs.yml
@@ -8,6 +8,3 @@ SilverStripe\Core\Injector\Injector:
   Symbiote\QueuedJobs\Services\QueuedJobService:
     properties:
       queueRunner: '%$Symbiote\QueuedJobs\Tasks\Engines\DoormanRunner'
-
-Symbiote\QueuedJobs\Services\QueuedJobsService:
-  time_limit: 600


### PR DESCRIPTION
The name of `QueuedJobService` is spelt incorrectly with an extra `s` hence the intended configuration is not applied since this is not mapped correctly according to its purpose.

Instead of renaming it properly the approach for this fix is to remove the configuration in its entirety for backwards compatibility.