### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/admin": "1.13.x-dev",
-        "silverstripe/hybridsessions": "2.7.x-dev",
-        "silverstripe/environmentcheck": "2.7.x-dev",
-        "silverstripe/auditor": "2.6.x-dev"
+        "silverstripe/framework": "^4.11",
+        "silverstripe/admin": "^1.10",
+        "silverstripe/hybridsessions": "^2",
+        "silverstripe/environmentcheck": "^2",
+        "silverstripe/auditor": "^2.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33