### PR TITLE
MNT Update unit test

### DIFF
--- a/tests/PasswordStrengthTest.php
+++ b/tests/PasswordStrengthTest.php
@@ -4,6 +4,8 @@ namespace CWP\Core\Tests;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Security\Member;
+use SilverStripe\Security\PasswordValidator;
+use SilverStripe\Core\Injector\Injector;
 
 /**
  * Indeed it appears to only be testing config settings, however that isn't the main goal of this minor test suite. The
@@ -26,6 +28,15 @@ use SilverStripe\Security\Member;
  */
 class PasswordStrengthTest extends SapphireTest
 {
+    protected function setUp(): void
+    {
+        // Out of the box, SapphireTest::setUp will deregister the PasswordValidator.
+        // However, we need a PasswordValidator for these tests to work.
+        $validator = Member::password_validator() ?: new PasswordValidator();
+        parent::setUp();
+        Member::set_password_validator($validator);
+    }
+
     public function testPasswordMinLength()
     {
         $passwordValidator = Member::password_validator();


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/34

Fixes https://github.com/silverstripe/cwp-core/actions/runs/4559370105/jobs/8043562334#step:12:69

` 1) CWP\Core\Tests\PasswordStrengthTest::testPasswordMinLength
Error: Call to a member function getMinLength() on null`

Issue came about because of this PR https://github.com/silverstripe/recipe-core/pull/86.

I think there's a weird code-path for how the PasswordValidator normally gets registered in the CMS which I wasn't able to quickly find via a debug, though I've manually confirmed again that it does work so no issue there.  It's just whatever code path that is taken in the CMS isn't also taken by unit-tests
