### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^7.3 || ^8.0",
-        "silverstripe/framework": "^4.11",
+        "silverstripe/framework": "^4.13",
         "silverstripe/admin": "^1.10",
         "silverstripe/hybridsessions": "^2",
         "silverstripe/environmentcheck": "^2",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Failing on Deprecation::isEnabled() on --prefer-lowest build

https://github.com/silverstripe/cwp-core/actions/runs/9851666788