### PR TITLE
ENH Exclude dev/check route from basic-auth check on test env

### DIFF
--- a/_config/security.yml
+++ b/_config/security.yml
@@ -66,11 +66,15 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Security\BasicAuthMiddleware:
     properties:
       # Enforce basic authentication in UAT environments for all routes except for the "change password" form
+      # and the dev/check routes
       URLPatterns:
         '#^Security/lostpassword#i': false
         '#^Security/changepassword#i': false
         '#^Security/resetaccount#i': false
+        '#^dev/check$#': false
+        '#^dev/check/.+#': false
         '#.*#': ACCESS_UAT_SERVER
+
   SilverStripe\Control\Middleware\CanonicalURLMiddleware:
     properties:
       # Enforce HTTPS everywhere since basic authentication is on everywhere


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-environmentcheck/issues/116

This is required to prevent the wildcard basic-auth in test/uat environments from conflicting with the basic auth that's "manually" added to the dev/check endpoint

silverstripe/environmentcheck is a [dependency](https://github.com/silverstripe/cwp-core/blob/3/composer.json#L15) of cwp/core so it's ok to add this config here